### PR TITLE
:fuelpump: feat: add GIT_PULL_REBASE parameter to make rebase configurable

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -3,6 +3,7 @@ PROJECT_DIRECTORY="/app/${DIRECTORY_NAME:-project}"
 SUBFOLDER=${SUBFOLDER_PATH:-""}  # Fetch the sub-folder path from an environment variable
 
 mkdir -p ~/.ssh
+git config --global pull.rebase ${GIT_PULL_REBASE:-false}
 
 if [ ! -d "$PROJECT_DIRECTORY/.git" ]; then
   echo "Cloning the repository: $REPO_URL"


### PR DESCRIPTION
Add an option to configure whether to enable rebase on pull.
Handy when working on a remote development server, constantly running `commit --amend` and pushing to a branch, with the current setup the image just crashes.

Do you know when it will be updated on the docker hub?
Thanks :)